### PR TITLE
Add enum fields to the protoc comparison test

### DIFF
--- a/src/main/scala/pbdirect/PBFieldReader.scala
+++ b/src/main/scala/pbdirect/PBFieldReader.scala
@@ -55,28 +55,20 @@ trait PBFieldReaderImplicits {
   implicit def optionalFieldReader[A](
       implicit reader: PBFieldReader[List[A]]
   ): PBFieldReader[Option[A]] =
-    instance { (index: Int, bytes: Array[Byte]) =>
-      reader.read(index, bytes).lastOption
-    }
+    instance((index: Int, bytes: Array[Byte]) => reader.read(index, bytes).lastOption)
 
   implicit def mapFieldReader[K, V](
       implicit reader: PBFieldReader[List[(K, V)]]
   ): PBFieldReader[Map[K, V]] =
-    instance { (index: Int, bytes: Array[Byte]) =>
-      reader.read(index, bytes).toMap
-    }
+    instance((index: Int, bytes: Array[Byte]) => reader.read(index, bytes).toMap)
 
   implicit def collectionMapFieldReader[K, V](
       implicit reader: PBFieldReader[List[(K, V)]]
   ): PBFieldReader[collection.Map[K, V]] =
-    instance { (index: Int, bytes: Array[Byte]) =>
-      reader.read(index, bytes).toMap
-    }
+    instance((index: Int, bytes: Array[Byte]) => reader.read(index, bytes).toMap)
 
   implicit def seqFieldReader[A](implicit reader: PBFieldReader[List[A]]): PBFieldReader[Seq[A]] =
-    instance { (index: Int, bytes: Array[Byte]) =>
-      reader.read(index, bytes)
-    }
+    instance((index: Int, bytes: Array[Byte]) => reader.read(index, bytes))
 
 }
 

--- a/src/main/scala/pbdirect/PBFieldWriter.scala
+++ b/src/main/scala/pbdirect/PBFieldWriter.scala
@@ -72,8 +72,7 @@ trait PBFieldWriterImplicits {
           value: collection.Map[K, V],
           out: CodedOutputStream,
           flags: PBFieldWriter.Flags
-      ) =>
-        writer.writeTo(index, value.toList, out, flags)
+      ) => writer.writeTo(index, value.toList, out, flags)
     }
 
   implicit def seqWriter[A](implicit writer: PBFieldWriter[List[A]]): PBFieldWriter[Seq[A]] =

--- a/src/main/scala/pbdirect/PBProductReader.scala
+++ b/src/main/scala/pbdirect/PBProductReader.scala
@@ -14,8 +14,7 @@ trait PBProductReaderImplicits {
     }
 
   implicit val hnilProductReader: PBProductReader[HNil, HNil] = PBProductReader.instance {
-    (indices: HNil, bytes: Array[Byte]) =>
-      HNil
+    (indices: HNil, bytes: Array[Byte]) => HNil
   }
 
   implicit def hconsProductReader[H, T <: HList, IT <: HList](

--- a/src/test/resources/proto/ProtocComparisonSpec.proto
+++ b/src/test/resources/proto/ProtocComparisonSpec.proto
@@ -36,4 +36,5 @@ message MessageThree {
   map<int32, MessageTwo> intMessageTwoMap = 12;
   map<sint32, fixed64> signedIntFixedLongMap = 13;
   Weather weather = 14;
+  repeated Weather weathers = 15;
 }

--- a/src/test/resources/proto/ProtocComparisonSpec.proto
+++ b/src/test/resources/proto/ProtocComparisonSpec.proto
@@ -1,5 +1,11 @@
 syntax = "proto3";
 
+enum Weather {
+  SUNNY = 0;
+  CLOUDY = 1;
+  RAINY = 2;
+}
+
 message MessageOne {
   double dbl = 1;
   bool boolean = 2;
@@ -29,4 +35,5 @@ message MessageThree {
   MessageTwo messageTwo = 11;
   map<int32, MessageTwo> intMessageTwoMap = 12;
   map<sint32, fixed64> signedIntFixedLongMap = 13;
+  Weather weather = 14;
 }

--- a/src/test/scala/pbdirect/ProtocComparisonSpec.scala
+++ b/src/test/scala/pbdirect/ProtocComparisonSpec.scala
@@ -85,6 +85,17 @@ class ProtocComparisonSpec extends AnyFlatSpec with Checkers {
 
 object ProtocComparisonSpec {
 
+  import enumeratum.values._
+  sealed abstract class Weather(val value: Int) extends IntEnumEntry
+  object Weather extends IntEnum[Weather] {
+    case object SUNNY  extends Weather(0)
+    case object CLOUDY extends Weather(1)
+    case object RAINY  extends Weather(2)
+
+    val values = findValues
+  }
+  implicit val arbWeather: Arbitrary[Weather] = Arbitrary(Gen.oneOf(Weather.values))
+
   case class MessageOne(
       dbl: Double,
       boolean: Boolean
@@ -109,7 +120,8 @@ object ProtocComparisonSpec {
       @pbIndex(10) messageOneOption: Option[MessageOne],
       @pbIndex(11) messageTwo: MessageTwo,
       @pbIndex(12) intMessageTwoMap: Map[Int, MessageTwo],
-      @pbIndex(13) signedIntFixedLongMap: Map[Int @@ Signed, Long @@ Fixed]
+      @pbIndex(13) signedIntFixedLongMap: Map[Int @@ Signed, Long @@ Fixed],
+      @pbIndex(14) weather: Weather
   )
 
   object TextFormatEncoding {
@@ -230,6 +242,7 @@ object ProtocComparisonSpec {
           |messageTwo: ${embeddedMessageTwo(m.messageTwo)}
           |${intMessageTwoMap(m.intMessageTwoMap)}
           |${signedIntFixedLongMap(m.signedIntFixedLongMap)}
+          |weather: ${m.weather.enumEntry}
           |""".stripMargin
     }
 

--- a/src/test/scala/pbdirect/ProtocComparisonSpec.scala
+++ b/src/test/scala/pbdirect/ProtocComparisonSpec.scala
@@ -121,7 +121,8 @@ object ProtocComparisonSpec {
       @pbIndex(11) messageTwo: MessageTwo,
       @pbIndex(12) intMessageTwoMap: Map[Int, MessageTwo],
       @pbIndex(13) signedIntFixedLongMap: Map[Int @@ Signed, Long @@ Fixed],
-      @pbIndex(14) weather: Weather
+      @pbIndex(14) weather: Weather,
+      @pbIndex(15) weathers: List[Weather]
   )
 
   object TextFormatEncoding {
@@ -243,6 +244,7 @@ object ProtocComparisonSpec {
           |${intMessageTwoMap(m.intMessageTwoMap)}
           |${signedIntFixedLongMap(m.signedIntFixedLongMap)}
           |weather: ${m.weather.enumEntry}
+          |weathers: [${m.weathers.map(_.enumEntry).mkString(", ")}]
           |""".stripMargin
     }
 

--- a/src/test/scala/pbdirect/RoundTripSpec.scala
+++ b/src/test/scala/pbdirect/RoundTripSpec.scala
@@ -131,9 +131,7 @@ trait PBEquivalenceImplicits_2 {
       override def show: String                 = description
     }
 
-  implicit def refl[A]: PBEquivalence[A] = instance("refl") { (a1, a2) =>
-    a1 == a2
-  }
+  implicit def refl[A]: PBEquivalence[A] = instance("refl")((a1, a2) => a1 == a2)
 
 }
 
@@ -141,9 +139,7 @@ trait PBEquivalenceImplicits_1 extends PBEquivalenceImplicits_2 {
 
   // special treatment for arrays because == doesn't work (it uses reference equality)
   implicit def array[A](implicit listEquiv: PBEquivalence[List[A]]): PBEquivalence[Array[A]] =
-    instance("array") { (a1, a2) =>
-      listEquiv.equiv(a1.toList, a2.toList)
-    }
+    instance("array")((a1, a2) => listEquiv.equiv(a1.toList, a2.toList))
 
   def option[A](description: String, defaultValue: A)(
       implicit equiv: PBEquivalence[A]


### PR DESCRIPTION
Just extending the test to validate my assumption that protoc encodes repeated enum fields the same way we do, i.e. using packed encoding.

The [Protobuf encoding doc](https://developers.google.com/protocol-buffers/docs/encoding#packed) is a bit vague on this point. It talks about "scalar numeric values" but does not mention enums specifically. I wanted to check protoc's behaviour as part of an investigation into an issue I'm raising in mu-haskell.