### PR TITLE
Deprecate Enum

### DIFF
--- a/src/main/scala/pbdirect/Enum.scala
+++ b/src/main/scala/pbdirect/Enum.scala
@@ -2,6 +2,7 @@ package pbdirect
 
 import shapeless.{:+:, CNil, Coproduct, Generic, Witness}
 
+@deprecated("Please use an enumeratum IntEnum instead", since = "0.5.2")
 object Enum {
   def values[T](implicit v: Values[T], ord: Ordering[T]): Seq[T]         = v.apply.sorted
   def fromInt[T](index: Int)(implicit v: Values[T], ord: Ordering[T]): T = values.apply(index)

--- a/src/main/scala/pbdirect/PBScalarValueReader.scala
+++ b/src/main/scala/pbdirect/PBScalarValueReader.scala
@@ -144,6 +144,7 @@ trait PBScalarValueReaderImplicits extends PBScalarValueReaderImplicits_1 {
       override def read(input: CodedInputStream): Array[Byte] = input.readByteArray()
     }
 
+  @deprecated("Please use an enumeratum IntEnum instead", since = "0.5.2")
   implicit def enumReader[A](
       implicit
       values: Enum.Values[A],

--- a/src/main/scala/pbdirect/PBScalarValueWriter.scala
+++ b/src/main/scala/pbdirect/PBScalarValueWriter.scala
@@ -242,6 +242,7 @@ trait PBScalarValueWriterImplicits extends LowPriorityPBScalarValueWriterImplici
       }
     }
 
+  @deprecated("Please use an enumeratum IntEnum instead", since = "0.5.2")
   implicit def enumWriter[E](
       implicit values: Enum.Values[E],
       ordering: Ordering[E]

--- a/src/main/scala/pbdirect/Pos.scala
+++ b/src/main/scala/pbdirect/Pos.scala
@@ -1,5 +1,6 @@
 package pbdirect
 
+@deprecated("Please use an enumeratum IntEnum instead", since = "0.5.2")
 trait Pos {
   val _pos: Int
 }


### PR DESCRIPTION
It's a maintenance burden (see https://github.com/47degrees/pbdirect/pull/84/commits/a8015a0d0e5bd2e25c486fecc538fc74d8d485eb) and it's been superseded by the support for Enumeratum.